### PR TITLE
Updated shasum.

### DIFF
--- a/Formula/julius-dictation-kit.rb
+++ b/Formula/julius-dictation-kit.rb
@@ -3,7 +3,7 @@ require 'formula'
 class JuliusDictationKit < Formula
   homepage 'http://julius.sourceforge.jp/'
   url 'http://sourceforge.jp/frs/redir.php?f=/julius/60416/dictation-kit-v4.3.1-osx.tgz'
-  sha1 '8b94b3dabf1ed27f94864e72767abb2fc274c5db'
+  sha1 '3e9fe6edcc3647192369cc08ac1725618eeb1551'
 
   def install
     prefix.install 'HOWTO.txt'


### PR DESCRIPTION
# dictation-kitのshasumをアップデートしました。

`brew tap oame/nlp` を行い、julia-dictation-kitをインストールしようとしたところ、
以下のエラーがでました。

![2014-05-16 1 32 51](https://cloud.githubusercontent.com/assets/72997/2987660/ddfbe65a-dc50-11e3-8c8f-30e192040c01.png)

dictation-kitを念のため直接ダウンロードし、
**shasum**コマンドで確認しましたが、結果が同じでした。

```
wget "http://sourceforge.jp/frs/redir.php?f=/julius/60416/dictation-kit-v4.3.1-osx.tgz" -O dictation-kit.tgz
```

![2014-05-16 1 37 37](https://cloud.githubusercontent.com/assets/72997/2987672/ed0bae46-dc50-11e3-9bae-ee2170789ca5.png)
# 確認した結果

Formulaのshasumを更新し、`brew tap futoase/nlp` を実行し、
インストールを行ったところ、問題はないことを確認できました。

![2014-05-16 1 43 41](https://cloud.githubusercontent.com/assets/72997/2987699/21522676-dc51-11e3-94bf-3a5f99a49057.png)

よろしければ、マージをお願いします。
