### PR TITLE
Change sha1 to sha256 in order to avoid sha1 deprecated warnings

### DIFF
--- a/Formula/chasen.rb
+++ b/Formula/chasen.rb
@@ -3,7 +3,7 @@ require "formula"
 class Chasen < Formula
   homepage "http://chasen-legacy.sourceforge.jp/"
   url "http://sourceforge.jp/frs/redir.php?f=/chasen-legacy/56305/chasen-2.4.5.tar.gz"
-  sha1 "a07d7f423531d2c155384bc6de64d515c5f0ac1c"
+  sha256 "fd1a7afd73ed14e18b0fe82965c00a6baae383070360a4220fde01338611416a"
 
   depends_on "darts"
 

--- a/Formula/darts.rb
+++ b/Formula/darts.rb
@@ -3,7 +3,7 @@ require "formula"
 class Darts < Formula
   homepage "http://chasen.org/~taku/software/darts/"
   url "http://chasen.org/~taku/software/darts/src/darts-0.32.tar.gz"
-  sha1 "14a20a36ded935bef2752a726e027baece7bc801"
+  sha256 "0dfc0b82f0a05d93b92acf849368e54bf93f1de8ffb31ba0a21e45ab9e269285"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/hts_engine_api.rb
+++ b/Formula/hts_engine_api.rb
@@ -3,7 +3,7 @@ require 'formula'
 class HtsEngineApi < Formula
   homepage ''
   url 'http://downloads.sourceforge.net/project/hts-engine/hts_engine%20API/hts_engine_API-1.09/hts_engine_API-1.09.tar.gz'
-  sha1 '1c264c2bd29c87f49ace2c5d2b2fcd6b5b44b12c'
+  sha256 'b35a9c7c6868e15be0fbfb91c7a3696cf623d82f2d2058d2fa4362c289b62895'
   version '1.09'
 
   def install

--- a/Formula/julius-dictation-kit.rb
+++ b/Formula/julius-dictation-kit.rb
@@ -3,7 +3,7 @@ require 'formula'
 class JuliusDictationKit < Formula
   homepage 'http://julius.sourceforge.jp/'
   url 'http://sourceforge.jp/frs/redir.php?f=/julius/60416/dictation-kit-v4.3.1-osx.tgz'
-  sha1 '3e9fe6edcc3647192369cc08ac1725618eeb1551'
+  sha256 '35f146bfeeafde44f91e72198aa38304d42610fc23d401cce9754668e2d0f238'
   version '4.3.1'
 
   def install

--- a/Formula/julius-grammar-kit.rb
+++ b/Formula/julius-grammar-kit.rb
@@ -3,7 +3,7 @@ require 'formula'
 class JuliusGrammarKit < Formula
   homepage 'http://julius.sourceforge.jp/'
   url 'http://sourceforge.jp/frs/redir.php?f=/julius/51159/grammar-kit-v4.1.tar.gz'
-  sha1 'e3cdbd69514dc77d6e0068960c5f3e2cd59c63a1'
+  sha256 'baf016e239b0809c55ba1d50bc2d265c09ae505965ac6d61ca73f61b31d005ef'
   version '4.1'
 
   def install

--- a/Formula/julius.rb
+++ b/Formula/julius.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Julius < Formula
   homepage 'http://julius.sourceforge.jp/'
   url 'http://sourceforge.jp/frs/redir.php?f=/julius/60273/julius-4.3.1.tar.gz'
-  sha1 '88f64ae9ed00b6ab5a2d4fe07e3ced141a46c196'
+  sha256 '4bf77c7b91f4bb0686c375c70bd4f2077e7de7db44f60716af9f3660f65a6253'
   version '4.3.1'
 
   def install

--- a/Formula/knp.rb
+++ b/Formula/knp.rb
@@ -3,7 +3,7 @@ require "formula"
 class Knp < Formula
   homepage "http://nlp.ist.i.kyoto-u.ac.jp/index.php?KNP"
   url "http://nlp.ist.i.kyoto-u.ac.jp/DLcounter/lime.cgi?down=http://nlp.ist.i.kyoto-u.ac.jp/nl-resource/knp/knp-4.16.tar.bz2&name=knp-4.16.tar.bz2"
-  sha1 "98ab94c30ebaaec88d8d8d7e7bb563eb8c62bd3f"
+  sha256 "a500e04cbf581eda4c8d2be93d6eff9066069b6287a465b6c4050604bd5faeb5"
 
   depends_on "juman"
   depends_on "tinycdb"

--- a/Formula/open_jtalk.rb
+++ b/Formula/open_jtalk.rb
@@ -3,7 +3,7 @@ require 'formula'
 class OpenJtalk < Formula
   homepage 'http://open-jtalk.sourceforge.net/'
   url 'http://downloads.sourceforge.net/project/open-jtalk/Open%20JTalk/open_jtalk-1.08/open_jtalk-1.08.tar.gz'
-  sha1 '34749abce5f8263ebbe9843b92407f4f0a742c66'
+  sha256 '4771014f71734653b158e1723fd8c5c4440246a1fcc83491d6aa1c791ee2109e'
   version '1.08'
 
   depends_on 'hts_engine_api'


### PR DESCRIPTION
Hi @uetchy , 

When I ran `brew tap uetchy/nlp`, I got these warning messages.

```bash
$ brew tap uetchy/nlp
==> Tapping uetchy/nlp
Cloning into '/usr/local/Homebrew/Library/Taps/uetchy/homebrew-nlp'...
remote: Counting objects: 12, done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 12 (delta 0), reused 6 (delta 0), pack-reused 0
Unpacking objects: 100% (12/12), done.
Checking connectivity... done.
Warning: Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Homebrew/Library/Taps/uetchy/homebrew-nlp/Formula/chasen.rb:6:in `<class:Chasen>'
Please report this to the uetchy/nlp tap!

Warning: Calling SoftwareSpec#sha1 is deprecated!
Use SoftwareSpec#sha256 instead.
/usr/local/Homebrew/Library/Taps/uetchy/homebrew-nlp/Formula/chasen.rb:6:in `<class:Chasen>'
Please report this to the uetchy/nlp tap!
...
```

So that, in 4f9d033, I change code to use `sha256` instead of `sha1`. When this commit is merged to current master, then deprecated messages will be removed. I confirmed it with `brew tap shotarok/nlp`.

```
$ brew tap shotarok/nlp
==> Tapping shotarok/nlp
Cloning into '/usr/local/Homebrew/Library/Taps/shotarok/homebrew-nlp'...
remote: Counting objects: 12, done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 12 (delta 0), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (12/12), done.
Checking connectivity... done.
Tapped 8 formulae (42 files, 29.2K)
```

I calculated the sha256 values like this.

```
$ openssl dgst -sha256 $(ls .)                                                  
SHA256(darts-0.32.tar.gz)= 0dfc0b82f0a05d93b92acf849368e54bf93f1de8ffb31ba0a21e45ab9e269285
SHA256(hts_engine_API-1.09.tar.gz)= b35a9c7c6868e15be0fbfb91c7a3696cf623d82f2d2058d2fa4362c289b62895
SHA256(lime.cgi?down=http:%2F%2Fnlp.ist.i.kyoto-u.ac.jp%2Fnl-resource%2Fknp%2Fknp-4.16.tar.bz2&name=knp-4.16.tar.bz2)= a500e04cbf581eda4c8d2be93d6eff9066069b6287a465b6c4050604bd5faeb5
SHA256(open_jtalk-1.08.tar.gz)= 4771014f71734653b158e1723fd8c5c4440246a1fcc83491d6aa1c791ee2109e
SHA256(redir.php?f=%2Fchasen-legacy%2F56305%2Fchasen-2.4.5.tar.gz)= fd1a7afd73ed14e18b0fe82965c00a6baae383070360a4220fde01338611416a
SHA256(redir.php?f=%2Fjulius%2F51159%2Fgrammar-kit-v4.1.tar.gz)= baf016e239b0809c55ba1d50bc2d265c09ae505965ac6d61ca73f61b31d005ef
SHA256(redir.php?f=%2Fjulius%2F60273%2Fjulius-4.3.1.tar.gz)= 4bf77c7b91f4bb0686c375c70bd4f2077e7de7db44f60716af9f3660f65a6253
SHA256(redir.php?f=%2Fjulius%2F60416%2Fdictation-kit-v4.3.1-osx.tgz)= 35f146bfeeafde44f91e72198aa38304d42610fc23d401cce9754668e2d0f238
```

Thanks,
Shotaro