### PR TITLE
Remove CRF++ dependency from the formula of KNP

### DIFF
--- a/Formula/knp.rb
+++ b/Formula/knp.rb
@@ -7,7 +7,6 @@ class Knp < Formula
 
   depends_on "juman"
   depends_on "tinycdb"
-  depends_on "crf++" => :reccomend
 
   def install
     args = %W[
@@ -17,8 +16,6 @@ class Knp < Formula
       --prefix=#{prefix}
       --with-juman-prefix=#{HOMEBREW_PREFIX}/opt/juman
     ]
-
-    args << "--with-crf" if build.with? "crf++"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Hello @uetchy 

According to the Japanese official site of KNP ([link](http://nlp.ist.i.kyoto-u.ac.jp/index.php?KNP%2F%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E6%96%B9%E6%B3%95)), KNP tarballs  after version 4.12 include CRF++, and they do not need to install CRF++ by yourself. So that I removed CRF++ dependency from the formula of KNP.

> knp-4.12以降はCRF++が同梱されるようになったので別途インストールする必要はなくなりました。

I confirmed that `brew install knp` with my repo and knp running successfully like this.

```bash
$ brew tap shotarok/nlp    
==> Tapping shotarok/nlp
Cloning into '/usr/local/Homebrew/Library/Taps/shotarok/homebrew-nlp'...
remote: Counting objects: 12, done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 12 (delta 0), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (12/12), done.
Checking connectivity... done.
Tapped 8 formulae (42 files, 29.5K)
$ brew install knp 
==> Installing knp from shotarok/nlp
==> Downloading http://nlp.ist.i.kyoto-u.ac.jp/DLcounter/lime.cgi?down=http://nlp.ist.i.kyoto-u.ac.jp/nl-resource/knp/knp-4.16.tar.bz2&name=knp-4.16.tar.bz2
Already downloaded: /Users/shotarok/Library/Caches/Homebrew/knp-4.16.tar.bz2
==> ./configure --disable-silent-rules --prefix=/usr/local/Cellar/knp/4.16 --with-juman-prefix=/usr/local/opt/juman
==> make install
🍺  /usr/local/Cellar/knp/4.16: 73 files, 3.0G, built in 9 minutes 17 seconds
$ echo "麻生太郎はコーヒーを買って飲んだ。" | juman | knp -simple -anaphora
# S-ID:1 KNP:4.16-CF1.1 DATE:2016/10/22 SCORE:-16.31767
* 3D <体言><係:未格>
+ 1D <係:文節内><体言><NE内:PERSON><EID:0>
麻生 あそう 麻生 名詞 6 人名 5 * 0 * 0 "人名:日本:姓:135:0.00166 疑似代表表記 代表表記:麻生/あそう" <NE:PERSON:B>
+ 4D <体言><係:未格><NE:PERSON:麻生太郎><EID:1>
太郎 たろう 太郎 名詞 6 人名 5 * 0 * 0 "人名:日本:名:45:0.00106 疑似代表表記 代表表記:太郎/たろう" <NE:PERSON:E>
は は は 助詞 9 副助詞 2 * 0 * 0 NIL 
* 3D <体言><係:ヲ格>
+ 4D <体言><係:ヲ格><EID:2>
コーヒー こーひー コーヒー 名詞 6 普通名詞 1 * 0 * 0 "代表表記:珈琲/こーひー カテゴリ:人工物-食べ物 ドメイン:料理・食事" 
を を を 助詞 9 格助詞 1 * 0 * 0 NIL 
* 3D <用言:動><係:連用>
+ 4D <用言:動><係:連用><EID:3><述語項構造:買う/かう:動2:ガ/O/麻生太郎/1;ヲ/O/コーヒー/2>
買って かって 買う 動詞 2 * 0 子音動詞ワ行 12 タ系連用テ形 14 "代表表記:買う/かう ドメイン:家庭・暮らし;ビジネス 反義:動詞:売る/うる" 
* -1D <用言:動><係:文末>
+ -1D <用言:動><係:文末><EID:4><述語項構造:飲む/のむ:動1:ガ/N/麻生太郎/1;ヲ/C/コーヒー/2>
飲んだ のんだ 飲む 動詞 2 * 0 子音動詞マ行 9 タ形 10 "代表表記:飲む/のむ ドメイン:料理・食事" 
。 。 。 特殊 1 句点 1 * 0 * 0 NIL 
EOS
```

Thanks,
Shotaro